### PR TITLE
Set up Sphinx documentation framework

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ submodules:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,11 @@ build:
   apt_packages:
     - libsndfile1 # on linux required for soundfile package
 
+# Include all git submodules, recursively
+submodules:
+  include: all
+  recursive: true
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,5 +19,4 @@ sphinx:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-    - method: pip
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.10"
   apt_packages:
     - libsndfile1 # on linux required for soundfile package
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - libsndfile1 # on linux required for soundfile package
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - method: pip
+    - requirements: requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,3 +31,28 @@ exclude_patterns = []
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_title = "CHORAS backend"
+
+html_theme_options = {
+    "navbar_start": ["navbar-logo"],
+    "navbar_end": ["navbar-icon-links", "theme-switcher"],
+    "navbar_align": "left",
+    "icon_links": [
+        {
+          "name": "GitHub",
+          "url": "https://github.com/choras-org/backend",
+          "icon": "fa-brands fa-square-github",
+          "type": "fontawesome",
+        },
+    ],
+    # Configure secondary (right) side bar
+    "show_toc_level": 3,  # Show all subsections of notebooks
+    "secondary_sidebar_items": ["page-toc"],  # Omit 'show source' link that that shows notebook in json format
+    "navigation_with_keys": True,
+    # Configure navigation depth for section navigation
+    "navigation_depth": 2,
+}
+
+html_context = {
+   "default_mode": "light"
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "Room Acoustics UI"
+project = "CHORAS backend"
 copyright = "2024, Hassan Teymoori"
 author = "Hassan Teymoori"
 release = "1.7"
@@ -20,7 +20,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "myst_parser",
-    "sphinx_design",
 ]
 source_suffix = [".rst", ".md"]
 
@@ -30,5 +29,5 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "furo"
+html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ pytest
 locust
 ezdxf
 modepy
-sphinx-pydata-theme # Docs theme
+pydata-sphinx-theme # Docs theme
 myst_parser # Docs, required for markdown support
 
 -e ./simulation-backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,13 +113,13 @@ scipy==1.14.0
 six==1.16.0
 snowballstemmer==2.2.0
 soundfile==0.13.1
-Sphinx==7.3.7
-sphinxcontrib-applehelp==1.0.8
-sphinxcontrib-devhelp==1.0.6
-sphinxcontrib-htmlhelp==2.0.5
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.7
-sphinxcontrib-serializinghtml==1.1.10
+Sphinx==7.3.7 # Docs
+sphinxcontrib-applehelp==1.0.8 # docs, potentially secondary requirement
+sphinxcontrib-devhelp==1.0.6 # docs, potentially secondary requirement
+sphinxcontrib-htmlhelp==2.0.5 # docs, potentially secondary requirement
+sphinxcontrib-jsmath==1.0.1 # docs, potentially secondary requirement
+sphinxcontrib-qthelp==1.0.7 # docs, potentially secondary requirement
+sphinxcontrib-serializinghtml==1.1.10 # docs, potentially secondary requirement
 SQLAlchemy==2.0.7
 sqlparse==0.4.4
 stack-data==0.6.2
@@ -143,6 +143,8 @@ pytest
 locust
 ezdxf
 modepy
+sphinx-pydata-theme # Docs theme
+myst_parser # Docs, required for markdown support
 
 -e ./simulation-backend
 -e ./Diffusion


### PR DESCRIPTION
I've updated the existing configuration and created a readthedocs config.
The docs are now built on readthedocs.org on every PR, tag, and commit to the main branch.
There's still some reorganization to be done but I think this makes sense within a separate PR.

- [x] Update Sphinx config 
- [x] Set up deployment/hosting via readthedocs.org
- [x] Update requirements.txt