### PR TITLE
Replace the git submodule for DE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Diffusion"]
-	path = Diffusion
-	url = https://github.com/Building-acoustics-TU-Eindhoven/Diffusion.git
 [submodule "MyNewMethod"]
 	path = MyNewMethod
 	url = https://github.com/SilvinWillemsen/MyNewMethod.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 COPY requirements.txt /app
 COPY simulation-backend/ /app/simulation-backend
-COPY Diffusion/ /app/Diffusion
 COPY MyNewMethod/ /app/MyNewMethod
 
 RUN pip install --upgrade pip
 RUN pip install simulation-backend/.
-RUN pip install Diffusion/.
 RUN pip install MyNewMethod/.
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,6 +152,6 @@ matplotlib<3.7.0 # Docs, required for plot directive
 pyroomacoustics
 
 -e ./simulation-backend
--e ./Diffusion
+git+https://github.com/Building-acoustics-TU-Eindhoven/acousticDE.git@36d1d2562f493f8616548f10a7e6d52f22f2a519#egg=acousticDE
 git+https://github.com/Building-acoustics-TU-Eindhoven/edg-acoustics.git@bf97d0355366540940adee3043e0bcca447254e8#egg=edg-acoustics
 -e ./MyNewMethod


### PR DESCRIPTION
Install via pip from GitHub instead.
The commit hash which is used for installation matches the commit hash of the submodule.
Should merge into #33 

Currently, the tests are failing due to #29. The respective failing test is not related to this PR and should be ignored here.