### PR TITLE
Add missing math import in geometry service

### DIFF
--- a/app/services/geometry_service.py
+++ b/app/services/geometry_service.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import zipfile
 


### PR DESCRIPTION
Required when converting a obj which is a mesh and not a pure geometry definition.