### PR TITLE
CI: Ignore tests which require more elaborate setup

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,4 +26,10 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Run tests
-        run: python -m pytest -v tests/unit/services/ tests/unit/models --ignore=tests/unit/executors/
+        run: |
+          python -m pytest -v \
+            tests/unit/services/ \
+            tests/unit/models \
+            --ignore=tests/unit/executors/ \
+            --ignore=tests/unit/services/test_discovery_service.py \
+            --ignore=tests/unit/services/test_run_solver.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,4 +25,4 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Run tests
-        run: python -m pytest -v tests/unit/services/ tests/unit/models
+        run: python -m pytest -v tests/unit/services/ tests/unit/models --ignore=tests/unit/executors/


### PR DESCRIPTION
The executor tests require setting up Mocks and Docker. The set-up for these is currently located in .github/workflows/engd2026.yml