### PR TITLE
DOC: Add services to API documentation

### DIFF
--- a/docs/source/includes/api_documentation.rst
+++ b/docs/source/includes/api_documentation.rst
@@ -1,6 +1,20 @@
 API Documentation
 =================
 
+Services
+--------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Implemented Interfaces:
+
+   api_documentation/executors.rst
+   api_documentation/discovery_service.rst
+   api_documentation/export_service.rst
+   api_documentation/file_service.rst
+   api_documentation/geometry_service.rst
+   api_documentation/material_service.rst
+   api_documentation/mesh_service.rst
+   api_documentation/model_service.rst
+   api_documentation/project_service.rst
+   api_documentation/setting_service.rst
+   api_documentation/simulation_service.rst

--- a/docs/source/includes/api_documentation/auralization_service.rst
+++ b/docs/source/includes/api_documentation/auralization_service.rst
@@ -1,0 +1,7 @@
+Auralization Service
+====================
+
+.. automodule:: app.services.auralization_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/discovery_service.rst
+++ b/docs/source/includes/api_documentation/discovery_service.rst
@@ -1,0 +1,7 @@
+Discovery Service
+=================
+
+.. automodule:: app.services.discovery_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/executors.rst
+++ b/docs/source/includes/api_documentation/executors.rst
@@ -1,0 +1,12 @@
+Executors
+=========
+
+.. automodule:: app.services.executors.local_executor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: app.services.executors.cloud_executor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/export_service.rst
+++ b/docs/source/includes/api_documentation/export_service.rst
@@ -1,0 +1,7 @@
+Export Service
+==============
+
+.. automodule:: app.services.export_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/file_service.rst
+++ b/docs/source/includes/api_documentation/file_service.rst
@@ -1,0 +1,7 @@
+File Service
+============
+
+.. automodule:: app.services.file_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/geometry_service.rst
+++ b/docs/source/includes/api_documentation/geometry_service.rst
@@ -1,0 +1,7 @@
+Geometry Service
+================
+
+.. automodule:: app.services.geometry_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/material_service.rst
+++ b/docs/source/includes/api_documentation/material_service.rst
@@ -1,0 +1,7 @@
+Material Service
+================
+
+.. automodule:: app.services.material_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/mesh_service.rst
+++ b/docs/source/includes/api_documentation/mesh_service.rst
@@ -1,0 +1,7 @@
+Mesh Service
+============
+
+.. automodule:: app.services.mesh_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/model_service.rst
+++ b/docs/source/includes/api_documentation/model_service.rst
@@ -1,0 +1,7 @@
+Model Service
+=============
+
+.. automodule:: app.services.model_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/project_service.rst
+++ b/docs/source/includes/api_documentation/project_service.rst
@@ -1,0 +1,7 @@
+Project Service
+===============
+
+.. automodule:: app.services.project_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/setting_service.rst
+++ b/docs/source/includes/api_documentation/setting_service.rst
@@ -1,0 +1,7 @@
+Setting Service
+===============
+
+.. automodule:: app.services.setting_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/includes/api_documentation/simulation_service.rst
+++ b/docs/source/includes/api_documentation/simulation_service.rst
@@ -1,0 +1,7 @@
+Simulation Service
+==================
+
+.. automodule:: app.services.simulation_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,3 +21,10 @@ Please follow the steps provided here to setup the CHORAS backend.
    :caption: Contribution Guidelines
 
    includes/contributing.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: API References
+
+   includes/api_documentation.rst


### PR DESCRIPTION
### Proposed Changes

- Create the necessary file structure to auto-generate docs for the services module
- Not all docstrings are populated yet, which is probably more feasible to extend in a separate PR