### PR TITLE
FEAT: Propagate error messages from simulation methods to database

### DIFF
--- a/app/models/Simulation.py
+++ b/app/models/Simulation.py
@@ -23,6 +23,7 @@ class Simulation(db.Model):
     settingsPreset = db.Column(db.Enum(Setting), default=Setting.Default)
     solverSettings = db.Column(JSON, nullable=False)
     status = db.Column(db.Enum(Status), default=Status.Created)
+    errorMessage = db.Column(db.String, nullable=True)
 
     modelId = db.Column(db.Integer, db.ForeignKey("models.id", ondelete="CASCADE"), nullable=False)
 

--- a/app/models/SimulationRun.py
+++ b/app/models/SimulationRun.py
@@ -19,6 +19,7 @@ class SimulationRun(db.Model):
     solverSettings = db.Column(JSON, nullable=False)
 
     status = db.Column(db.Enum(Status), default=Status.Created)
+    errorMessage = db.Column(db.String, nullable=True)
 
     createdAt = db.Column(db.String, default=datetime.now)
     updatedAt = db.Column(db.String, default=datetime.now, onupdate=datetime.now)

--- a/app/schemas/simulation_schema.py
+++ b/app/schemas/simulation_schema.py
@@ -30,7 +30,7 @@ class SimulationSchema(SimulationCreateBodySchema):
     createdAt = fields.String()
     updatedAt = fields.String()
     completedAt = fields.String(allow_none=True)
-    errorMessage = fields.Str(allow_none=True)
+    errorMessage = fields.Str(allow_none=True, dump_only=True)
 
 
 class SimulationUpdateBodySchema(SimulationSchema):
@@ -71,7 +71,7 @@ class SimulationRunSchema(Schema):
     updatedAt = fields.String()
     completedAt = fields.String()
     simulation = fields.Nested(SimulationWithModelInfoSchema)
-    errorMessage = fields.Str(allow_none=True)
+    errorMessage = fields.Str(allow_none=True, dump_only=True)
 
 
 class SimulationCancelSchema(Schema):

--- a/app/schemas/simulation_schema.py
+++ b/app/schemas/simulation_schema.py
@@ -30,6 +30,7 @@ class SimulationSchema(SimulationCreateBodySchema):
     createdAt = fields.String()
     updatedAt = fields.String()
     completedAt = fields.String(allow_none=True)
+    errorMessage = fields.Str(allow_none=True)
 
 
 class SimulationUpdateBodySchema(SimulationSchema):
@@ -70,6 +71,7 @@ class SimulationRunSchema(Schema):
     updatedAt = fields.String()
     completedAt = fields.String()
     simulation = fields.Nested(SimulationWithModelInfoSchema)
+    errorMessage = fields.Str(allow_none=True)
 
 
 class SimulationCancelSchema(Schema):

--- a/app/services/executors/cloud_executor.py
+++ b/app/services/executors/cloud_executor.py
@@ -103,22 +103,31 @@ class _CompletedJob:
     Since CloudExecutor.execute() already blocks until the job is fully done
     (via poll_until_complete), wait() is a no-op here.
     """
+    def __init__(self, exit_code: int = 0, logs_output: str = "Cloud job submitted."):
+        """Initialize the completed job.
+
+        Args:
+            exit_code: The exit code of the remote job (0 for success, non-zero for failure)
+            logs_output: Log message to return
+        """
+        self._exit_code = exit_code
+        self._logs_output = logs_output
+
     def wait(self):
         """Block until the job finishes (no-op for already-completed jobs).
 
         Returns:
-            dict: A status dict with ``{"StatusCode": 0}`` indicating
-                successful completion.
+            dict: A status dict with ``{"StatusCode": <exit_code>}``
         """
-        return {"StatusCode": 0}
+        return {"StatusCode": self._exit_code}
 
     def logs(self):
         """Return a placeholder log message for the completed cloud job.
 
         Returns:
-            bytes: A static byte string indicating a cloud submission.
+            bytes: A byte string with job information.
         """
-        return b"Cloud job submitted."
+        return self._logs_output.encode('utf-8')
 
 class CloudExecutor(SimulationExecutor):
     """Executes simulations on a remote HPC cluster via SSH and Singularity.
@@ -442,8 +451,8 @@ class CloudExecutor(SimulationExecutor):
         remote_app_dir: str,
         remote_sandbox_path: str,
         remote_tar_path: Optional[str] = None,
-    ) -> bool:
-        """Adaptively poll the remote job until all results reach 100 % progress.
+    ) -> tuple[bool, int]:
+        """Adaptively poll the remote job until all results reach 100 % progress or an error occurs.
 
         Opens a fresh SSH connection each cycle to download the output JSON,
         parse progress, and—if progress changed—persist the JSON locally so
@@ -471,9 +480,9 @@ class CloudExecutor(SimulationExecutor):
                 tarball, used for cleanup. Defaults to ``None``.
 
         Returns:
-            bool: ``True`` if outputs were collected and the remote workspace
-                was cleaned up successfully; ``False`` if an error occurred
-                during :meth:`_collect_outputs_and_cleanup`.
+            tuple[bool, int]: A tuple of (success, exit_code) where:
+                - success: ``True`` if outputs were collected and cleaned up successfully
+                - exit_code: 0 for success, 1 for error in simulation
         """
         local_json_path = os.path.join(local_uploads_dir, Path(remote_json_path).name)
 
@@ -487,8 +496,8 @@ class CloudExecutor(SimulationExecutor):
         while True:
             if self._should_cancel():
                 print("[Polling] Cancel requested. Exiting.")
-                return
-            
+                return (False, 0)
+
             cycle += 1
             print(f"[Polling] Cycle {cycle} (interval={poll_interval:.0f}s)")
 
@@ -519,6 +528,22 @@ class CloudExecutor(SimulationExecutor):
                 time.sleep(poll_interval)
                 continue
 
+            # Check for error in JSON (simulation failed)
+            if "error" in json_data:
+                print(f"[Polling] Error detected in JSON: {json_data['error']}")
+                # Save the error JSON locally
+                shutil.move(tmp_path, local_json_path)
+                print(f"[Polling] Error JSON written to {local_json_path}")
+                # Cleanup and return error exit code
+                success = self._collect_outputs_and_cleanup(
+                    remote_app_dir      = remote_app_dir,
+                    local_uploads_dir   = local_uploads_dir,
+                    remote_sandbox_path = remote_sandbox_path,
+                    remote_tar_path     = remote_tar_path,
+                )
+                # Exit code 1 for error
+                return (success, 1)
+
             current_progress = self._parse_overall_progress(json_data)
             print(f"[Polling] Progress: {current_progress}%")
 
@@ -543,7 +568,7 @@ class CloudExecutor(SimulationExecutor):
                     remote_tar_path     = remote_tar_path,
                 )
 
-                return success
+                return (success, 0)  # Exit code 0 for success
 
             if cycle >= POLL_FAST_PHASE_CYCLES:
                 poll_interval = min(
@@ -783,7 +808,7 @@ class CloudExecutor(SimulationExecutor):
 
         remote_app_dir_path = f"{self.remote_work_dir}/{sandbox_name}/app"
 
-        self._poll_until_complete(
+        success, exit_code = self._poll_until_complete(
             remote_json_path    = f"{remote_app_dir_path}/{json_filename}",
             local_uploads_dir   = local_uploads_dir,
             remote_app_dir      = remote_app_dir_path,
@@ -791,7 +816,15 @@ class CloudExecutor(SimulationExecutor):
             remote_tar_path     = f"{self.remote_work_dir}/{tar_image_name}",
         )
 
-        return _CompletedJob()
+        # Build log message
+        if exit_code != 0:
+            logs_output = f"Cloud job completed with error (exit code {exit_code})"
+        elif not success:
+            logs_output = "Cloud job completed but cleanup failed"
+        else:
+            logs_output = "Cloud job completed successfully"
+
+        return _CompletedJob(exit_code=exit_code, logs_output=logs_output)
 
     def cancel(self, cancelation_info: Dict[str, Any]):
         """Cancel a running Singularity job and clean up the remote workspace.

--- a/app/services/executors/cloud_executor.py
+++ b/app/services/executors/cloud_executor.py
@@ -482,7 +482,7 @@ class CloudExecutor(SimulationExecutor):
         Returns:
             tuple[bool, int]: A tuple of (success, exit_code) where:
                 - success: ``True`` if outputs were collected and cleaned up successfully
-                - exit_code: 0 for success, 1 for simulation error, 130 for cancellation
+                - exit_code: 0 for success, 1 for simulation error, 137 for cancellation
         """
         local_json_path = os.path.join(local_uploads_dir, Path(remote_json_path).name)
 
@@ -496,8 +496,9 @@ class CloudExecutor(SimulationExecutor):
         while True:
             if self._should_cancel():
                 print("[Polling] Cancel requested. Exiting.")
-                # 130 = 128 + SIGINT(2): Unix convention for user-initiated cancellation
-                return (False, 130)
+                # 137 = 128 + SIGKILL(9): Unix convention for termination due to signal 9 (SIGKILL)
+                # This is used here to comply with the implementation for local Docker container usage
+                return (False, 137)
 
             cycle += 1
             print(f"[Polling] Cycle {cycle} (interval={poll_interval:.0f}s)")
@@ -818,7 +819,7 @@ class CloudExecutor(SimulationExecutor):
         )
 
         # Build log message
-        if exit_code == 130:
+        if exit_code == 137:
             logs_output = "Cloud job was cancelled"
         elif exit_code != 0:
             logs_output = f"Cloud job completed with error (exit code {exit_code})"

--- a/app/services/executors/cloud_executor.py
+++ b/app/services/executors/cloud_executor.py
@@ -482,7 +482,7 @@ class CloudExecutor(SimulationExecutor):
         Returns:
             tuple[bool, int]: A tuple of (success, exit_code) where:
                 - success: ``True`` if outputs were collected and cleaned up successfully
-                - exit_code: 0 for success, 1 for error in simulation
+                - exit_code: 0 for success, 1 for simulation error, 130 for cancellation
         """
         local_json_path = os.path.join(local_uploads_dir, Path(remote_json_path).name)
 
@@ -496,7 +496,8 @@ class CloudExecutor(SimulationExecutor):
         while True:
             if self._should_cancel():
                 print("[Polling] Cancel requested. Exiting.")
-                return (False, 0)
+                # 130 = 128 + SIGINT(2): Unix convention for user-initiated cancellation
+                return (False, 130)
 
             cycle += 1
             print(f"[Polling] Cycle {cycle} (interval={poll_interval:.0f}s)")
@@ -817,7 +818,9 @@ class CloudExecutor(SimulationExecutor):
         )
 
         # Build log message
-        if exit_code != 0:
+        if exit_code == 130:
+            logs_output = "Cloud job was cancelled"
+        elif exit_code != 0:
             logs_output = f"Cloud job completed with error (exit code {exit_code})"
         elif not success:
             logs_output = "Cloud job completed but cleanup failed"

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import traceback
 from datetime import datetime
 from pathlib import Path
 
@@ -564,8 +565,6 @@ def run_solver(simulation_run_id: int, json_path: str):
             session.commit()
         except Exception as ex:
             # Unexpected errors - log full details but show generic message
-            import traceback
-
             error_details = traceback.format_exc()
             logger.error(f"Unexpected simulation error:\n{error_details}")
 

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -581,7 +581,6 @@ def run_solver(simulation_run_id: int, json_path: str):
         session.rollback()
         error_msg = f"Failed to initialize simulation: {str(ex)}"
         logger.error(error_msg)
-        abort(400, message=error_msg)
 
     finally:
         session.close()  # Ensure the session is closed after use

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -403,23 +403,44 @@ def run_solver(simulation_run_id: int, json_path: str):
             print(f"Resource type: {resource_type.value}")
 
             entry_file = discover_entry_file(simulation_method)
-
             executor = executor_factory(resource_type, entry_file)
 
-            #Relevant method container would be started dynamically based on the container_image
+            # Relevant method container is started dynamically based on the container_image
             method_config = {
                 "container_image": container_image,
                 "simulation_method": simulation_method.lower(),
-                "simulation_id":  str(simulation.id),
-                "task_id": result_container["task_id"]
+                "simulation_id": str(simulation.id),
+                "task_id": result_container["task_id"],
             }
 
-            logger.info(f"{simulation_method} Simulation_service:...container has been spinned up.")
+            logger.info(
+                f"{simulation_method} Simulation_service:...container is spinning up."
+            )
             container = executor.execute(method_config, sim_config)
-            container.wait()
-            logger.info(f"{simulation_method} Simulation_service:...container has finished.")
+            container_result = container.wait()
 
-            cancel_flag_path = Path(json_path).parent / f"{result_container['task_id']}.cancel"
+            exit_code = container_result["StatusCode"]
+            if exit_code != 0:
+                # Try to read structured error from JSON
+                try:
+                    with open(json_path, "r") as f:
+                        result = json.load(f)
+                        error_info = result.get("error", {})
+                        error_msg = error_info.get(
+                            "message", "Simulation container failed"
+                        )
+                except Exception:
+                    error_msg = f"Simulation failed with exit code {exit_code}"
+
+                raise RuntimeError(error_msg)
+
+            logger.info(
+                f"{simulation_method} Simulation_service:...container has finished."
+            )
+
+            cancel_flag_path = (
+                Path(json_path).parent / f"{result_container['task_id']}.cancel"
+            )
 
             # auralization: generate impulse response wav file
             # TODO: move the auralization calculation to DE and write that
@@ -529,15 +550,37 @@ def run_solver(simulation_run_id: int, json_path: str):
 
             session.commit()
             logger.info(f"SimulationRun status updated to {simulation_run.status}")
-        except Exception as ex:
+
+        except RuntimeError as ex:
+            # These are errors explicitly raised in the simulation-method
+            # including a meaningful error message.
+            # Propagate error messages to the database (frontend).
+            error_msg = str(ex)
+            logger.error(f"Simulation error: {error_msg}")
             simulation_run.status = Status.Error
+            simulation_run.errorMessage = error_msg
             simulation.status = Status.Error
+            simulation.errorMessage = error_msg
             session.commit()
-            logger.error(f"Cannot run the method because: {ex}")
+        except Exception as ex:
+            # Unexpected errors - log full details but show generic message
+            import traceback
+
+            error_details = traceback.format_exc()
+            logger.error(f"Unexpected simulation error:\n{error_details}")
+
+            error_msg = f"An unexpected error occurred: {str(ex)}"
+            simulation_run.status = Status.Error
+            simulation_run.errorMessage = error_msg
+            simulation.status = Status.Error
+            simulation.errorMessage = error_msg
+            session.commit()
 
     except Exception as ex:
-        session.rollback()
-        logger.error(f"Cannot update simulation run: {ex}")
+        db.session.rollback()
+        error_msg = f"Failed to initialize simulation: {str(ex)}"
+        logger.error(error_msg)
+        abort(400, message=error_msg)
 
     finally:
         session.close()  # Ensure the session is closed after use

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -433,7 +433,10 @@ def run_solver(simulation_run_id: int, json_path: str):
                 except Exception:
                     pass
 
-                raise RuntimeError(error_msg or f"Simulation failed with exit code {exit_code}")
+                fallback_msg = f"No error message was provided. Please check the container logs or terminal output for more details. Exit code {exit_code}."
+                raise RuntimeError(
+                    error_msg or fallback_msg,
+                )
 
             logger.info(
                 f"{simulation_method} Simulation_service:...container has finished."

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -421,18 +421,18 @@ def run_solver(simulation_run_id: int, json_path: str):
 
             exit_code = container_result["StatusCode"]
             if exit_code != 0:
-                # Try to read structured error from JSON
+                # Try to read a structured error written by the simulation container
+                # (or moved into place by the cloud executor on remote failure).
+                # If the container exits without writing {"error": {"message": ...}}
+                # to the JSON, the generic fallback is used instead.
+                error_msg = None
                 try:
                     with open(json_path, "r") as f:
-                        result = json.load(f)
-                        error_info = result.get("error", {})
-                        error_msg = error_info.get(
-                            "message", "Simulation container failed"
-                        )
+                        error_msg = json.load(f).get("error", {}).get("message")
                 except Exception:
-                    error_msg = f"Simulation failed with exit code {exit_code}"
+                    pass
 
-                raise RuntimeError(error_msg)
+                raise RuntimeError(error_msg or f"Simulation failed with exit code {exit_code}")
 
             logger.info(
                 f"{simulation_method} Simulation_service:...container has finished."

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -577,7 +577,7 @@ def run_solver(simulation_run_id: int, json_path: str):
             session.commit()
 
     except Exception as ex:
-        db.session.rollback()
+        session.rollback()
         error_msg = f"Failed to initialize simulation: {str(ex)}"
         logger.error(error_msg)
         abort(400, message=error_msg)

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -261,6 +261,7 @@ def start_solver_task(simulation_id):
     try:
         simulation.completedAt = ""
         simulation.status = Status.Created
+        simulation.errorMessage = None
 
         db.session.add(new_simulation_run)
         db.session.commit()

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -420,30 +420,52 @@ def run_solver(simulation_run_id: int, json_path: str):
             container = executor.execute(method_config, sim_config)
             container_result = container.wait()
 
+            cancel_flag_path = (
+                Path(json_path).parent / f"{result_container['task_id']}.cancel"
+            )
+
             exit_code = container_result["StatusCode"]
-            if exit_code != 0:
+            cancelled = exit_code == 137 and os.path.exists(cancel_flag_path)
+
+            if exit_code != 0 and not cancelled:
                 # Try to read a structured error written by the simulation container
                 # (or moved into place by the cloud executor on remote failure).
                 # If the container exits without writing {"error": {"message": ...}}
                 # to the JSON, the generic fallback is used instead.
-                error_msg = None
-                try:
-                    with open(json_path, "r") as f:
-                        error_msg = json.load(f).get("error", {}).get("message")
-                except Exception:
-                    pass
+                post_msg = "Please check the container logs or terminal output for more details."
+                logger.error(f"Docker container exited with code {exit_code}")
+                if exit_code == 1:
+                    fallback_msg = post_msg
+                    try:
+                        with open(json_path, "r") as f:
+                            error_msg = json.load(f).get("error", {}).get("message")
+                        if error_msg is None or error_msg.strip() == "":
+                            error_msg = fallback_msg
+                    except Exception:
+                        error_msg = fallback_msg
+                elif exit_code in (126, 127):
+                    error_msg = (
+                        "Docker container failed to execute. "
+                        "This may be due to a missing or misconfigured simulation "
+                        "method interface in the container image. "
+                        + post_msg
+                    )
+                elif exit_code == 137:
+                    error_msg = (
+                        "Docker container was killed. "
+                        "This may be due to insufficient resources (e.g., memory). "
+                        + post_msg
+                    )
+                else:
+                    error_msg = (
+                        f"Docker container exited with code {exit_code}. "
+                        + post_msg
+                    )
 
-                fallback_msg = f"No error message was provided. Please check the container logs or terminal output for more details. Exit code {exit_code}."
-                raise RuntimeError(
-                    error_msg or fallback_msg,
-                )
+                raise RuntimeError(error_msg)
 
             logger.info(
                 f"{simulation_method} Simulation_service:...container has finished."
-            )
-
-            cancel_flag_path = (
-                Path(json_path).parent / f"{result_container['task_id']}.cancel"
             )
 
             # auralization: generate impulse response wav file

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -553,6 +553,7 @@ def run_solver(simulation_run_id: int, json_path: str):
             logger.info(f"SimulationRun status updated to {simulation_run.status}")
 
         except RuntimeError as ex:
+            session.rollback()
             # These are errors explicitly raised in the simulation-method
             # including a meaningful error message.
             # Propagate error messages to the database (frontend).
@@ -564,6 +565,7 @@ def run_solver(simulation_run_id: int, json_path: str):
             simulation.errorMessage = error_msg
             session.commit()
         except Exception as ex:
+            session.rollback()
             # Unexpected errors - log full details but show generic message
             error_details = traceback.format_exc()
             logger.error(f"Unexpected simulation error:\n{error_details}")

--- a/tests/integration/test_cloud_executor_final.py
+++ b/tests/integration/test_cloud_executor_final.py
@@ -537,7 +537,7 @@ class TestPollUntilComplete:
                 remote_tar_path="/remote/image.tar",
             )
 
-        assert result is True
+        assert result == (True, 0)
         mock_cleanup.assert_called_once()
 
     def test_json_only_written_locally_when_progress_changes(self, tmp_path):
@@ -608,7 +608,7 @@ class TestPollUntilComplete:
                 remote_sandbox_path="/remote/sandbox",
             )
 
-        assert result is True
+        assert result == (True, 0)
 
     def test_cancel_flag_before_polling_exits_immediately(self, tmp_path):
         """
@@ -839,7 +839,7 @@ class TestExecuteHappyPath:
             "_upload_file_via_sftp":      MagicMock(),
             "_build_singularity_image":   MagicMock(),
             "_execute_singularity_image": MagicMock(),
-            "_poll_until_complete":       MagicMock(return_value=True),
+            "_poll_until_complete":       MagicMock(return_value=(True, 0)),
         }
 
     def _write_sim_config(self, tmp_path):

--- a/tests/integration/test_combined_improved.py
+++ b/tests/integration/test_combined_improved.py
@@ -687,7 +687,7 @@ class TestPollUntilComplete:
                 remote_sandbox_path="/remote/sandbox",
                 remote_tar_path="/remote/image.tar",
             )
-        assert result is True
+        assert result == (True, 0)
         mock_cleanup.assert_called_once()
 
     def test_full_chain_poll_to_completion_writes_output_files(self, tmp_path):
@@ -736,7 +736,7 @@ class TestPollUntilComplete:
                 remote_tar_path="/remote/image.tar",
             )
 
-        assert result is True
+        assert result == (True, 0)
         output_files = list(tmp_path.glob("*.json")) + list(tmp_path.glob("*.csv"))
         assert len(output_files) > 0
 
@@ -796,7 +796,7 @@ class TestPollUntilComplete:
                 remote_app_dir="/remote/app",
                 remote_sandbox_path="/remote/sandbox",
             )
-        assert result is True
+        assert result == (True, 0)
 
     def test_cancel_flag_before_polling_exits_immediately(self, tmp_path):
         """I15 — EP-P6: cancel flag at entry → exits immediately, nothing downloaded."""
@@ -911,7 +911,7 @@ class TestExecuteHappyPath:
             "_upload_file_via_sftp":      MagicMock(),
             "_build_singularity_image":   MagicMock(),
             "_execute_singularity_image": MagicMock(),
-            "_poll_until_complete":       MagicMock(return_value=True),
+            "_poll_until_complete":       MagicMock(return_value=(True, 0)),
         }
 
     def _write_sim_config(self, tmp_path):

--- a/tests/unit/schemas/test_simulation_schema.py
+++ b/tests/unit/schemas/test_simulation_schema.py
@@ -1,0 +1,47 @@
+import unittest
+
+from app.schemas.simulation_schema import SimulationRunSchema, SimulationSchema
+from app.types import Setting, Status
+
+
+class SimulationSchemaErrorMessageTests(unittest.TestCase):
+    """Tests for the errorMessage field added to SimulationSchema and SimulationRunSchema."""
+
+    def test_error_message_present_in_simulation_output(self):
+        """SimulationSchema serialises errorMessage when set."""
+        message = "Room geometry is invalid"
+        result = SimulationSchema().dump({
+            "status": Status.Error,
+            "errorMessage": message,
+        })
+        self.assertEqual(result["errorMessage"], message)
+
+    def test_error_message_present_in_simulation_run_output(self):
+        """SimulationRunSchema serialises errorMessage when set."""
+        message = "Solver failed"
+        result = SimulationRunSchema().dump({
+            "status": Status.Error,
+            "simulationMethod": "DE",
+            "settingsPreset": Setting.Default,
+            "errorMessage": message,
+        })
+        self.assertEqual(result["errorMessage"], message)
+
+    def test_error_message_dump_only(self):
+        """
+        errorMessage provided in load input raises ValidationError.
+
+        dump_only=True causes Marshmallow to treat the field as unknown during
+        deserialisation. Marshmallow raises ValidationError for unknown fields
+        by default, so a client sending errorMessage in a request body receives
+        a validation error rather than having the value silently accepted.
+        """
+        from marshmallow.exceptions import ValidationError
+        with self.assertRaises(ValidationError) as ctx:
+            SimulationSchema().load({
+                "name": "Test Simulation",
+                "modelId": 1,
+                "status": Status.Created,
+                "errorMessage": "should be rejected",
+            })
+        self.assertIn("errorMessage", ctx.exception.messages)

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -396,8 +396,8 @@ class RunSolverErrorMessageTests(BaseTestCase):
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
 
-        self.assertEqual(mock_simrun.errorMessage, "Simulation failed with exit code 1")
-        self.assertEqual(mock_simulation.errorMessage, "Simulation failed with exit code 1")
+        self.assertIn("Exit code 1", mock_simrun.errorMessage)
+        self.assertIn("Exit code 1", mock_simulation.errorMessage)
 
     @patch("app.services.simulation_service.executor_factory")
     @patch("app.services.simulation_service.discover_entry_file")
@@ -435,8 +435,8 @@ class RunSolverErrorMessageTests(BaseTestCase):
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
 
-        self.assertEqual(mock_simrun.errorMessage, "Simulation failed with exit code 1")
-        self.assertEqual(mock_simulation.errorMessage, "Simulation failed with exit code 1")
+        self.assertIn("Exit code 1", mock_simrun.errorMessage)
+        self.assertIn("Exit code 1", mock_simulation.errorMessage)
 
     @patch("app.services.simulation_service.executor_factory")
     @patch("app.services.simulation_service.discover_entry_file")

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -298,3 +298,207 @@ class RunSolverUnitTests(BaseTestCase):
             "❌ Malformed solverSettings → Simulation status should be Error")
         print("✅ Malformed solverSettings → Error status set correctly")
 
+
+class RunSolverErrorMessageTests(BaseTestCase):
+    """Verify errorMessage is written to both SimulationRun and Simulation on failure."""
+
+    def setUp(self):
+        super().setUp()
+        self.simulation_run_id = 123
+        fd, self.json_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        self._base_json = {
+            "task_id": "test-task-error",
+            "simulationSettings": {},
+            "results": [{"resultType": "DE", "responses": [{"receiverResults": []}]}],
+        }
+        with open(self.json_path, "w") as f:
+            json.dump(self._base_json, f)
+
+    def tearDown(self):
+        if os.path.exists(self.json_path):
+            os.chmod(self.json_path, 0o644)
+            os.unlink(self.json_path)
+        super().tearDown()
+
+    def _make_mock_session(self, mock_simrun, mock_simulation):
+        mock_session = MagicMock()
+        def query_side_effect(model_class):
+            mock_query = MagicMock()
+            if model_class.__name__ == "SimulationRun":
+                mock_query.get.return_value = mock_simrun
+            elif model_class.__name__ == "Simulation":
+                mock_query.filter_by.return_value.first.return_value = mock_simulation
+            return mock_query
+        mock_session.query.side_effect = query_side_effect
+        return mock_session
+
+    def _make_mock_simrun(self):
+        m = MagicMock()
+        m.id = self.simulation_run_id
+        m.status = Status.Created
+        return m
+
+    def _make_mock_simulation(self):
+        m = MagicMock()
+        m.id = 456
+        m.solverSettings = {"simulationSettings": {}}
+        m.settingsPreset = MagicMock(value="Default")
+        m.simulationMethod = "DE"
+        m.resourceType = ResourceType.LOCAL
+        m.status = Status.Created
+        m.simulationRunId = self.simulation_run_id
+        return m
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_json_error_message_written_to_both_models(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """Exit code 1 + JSON {"error": {"message": "..."}} → exact string on both models."""
+        error_message = "Room geometry is invalid"
+        with open(self.json_path, "w") as f:
+            json.dump({**self._base_json, "error": {"message": error_message}}, f)
+
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 1}
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.errorMessage, error_message)
+        self.assertEqual(mock_simulation.errorMessage, error_message)
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_missing_error_key_uses_fallback_message(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """Exit code 1 + JSON has no \"error\" key → fallback message on both models."""
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 1}
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.errorMessage, "Simulation failed with exit code 1")
+        self.assertEqual(mock_simulation.errorMessage, "Simulation failed with exit code 1")
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_unreadable_json_uses_fallback_message(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """
+        Exit code 1 + JSON not readable when error path runs → fallback message on both models.
+
+        run_solver reads the JSON twice: once at startup to load the task config, and
+        again after a non-zero exit code to extract the structured error message. This
+        test covers the case where the second read fails (e.g. the simulation container
+        overwrote or removed the file before exiting).
+
+        Timing is controlled via wait()'s side_effect: the file is deleted at the
+        moment wait() returns, which is after the initial reads and write-back but
+        before the error-path read — the exact window where this failure can occur
+        in production.
+        """
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+
+        def remove_json_and_fail(*args, **kwargs):
+            os.unlink(self.json_path)
+            return {"StatusCode": 1}
+
+        mock_executor_factory.return_value.execute.return_value.wait.side_effect = remove_json_and_fail
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.errorMessage, "Simulation failed with exit code 1")
+        self.assertEqual(mock_simulation.errorMessage, "Simulation failed with exit code 1")
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_unexpected_exception_writes_error_message(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """Unexpected exception (non-RuntimeError) in inner try → \"An unexpected error occurred: ...\" on both models."""
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.side_effect = ValueError("Connection lost")
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.errorMessage, "An unexpected error occurred: Connection lost")
+        self.assertEqual(mock_simulation.errorMessage, "An unexpected error occurred: Connection lost")
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_error_message_committed(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """
+        errorMessage is set on both models before session.commit() is called.
+
+        Setting errorMessage on the in-memory object is not enough — it must be
+        committed to actually reach the database. This test verifies the ordering
+        by recording the value of simulation_run.errorMessage each time commit()
+        fires. Early commits (status → Queued, status → InProgress) happen before
+        errorMessage is set, so they record the default MagicMock attribute. Only
+        the commit inside the error handler fires after the assignment, recording
+        the actual error string. The assertion passes only if that string appears
+        in the captured list, i.e. only if commit was called after the assignment.
+        """
+        error_message = "Simulation method failure"
+        with open(self.json_path, "w") as f:
+            json.dump({**self._base_json, "error": {"message": error_message}}, f)
+
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_session = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_scoped.return_value.return_value = mock_session
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 1}
+
+        # Record the value of errorMessage on simrun at the moment each commit fires
+        committed_messages = []
+        mock_session.commit.side_effect = lambda: committed_messages.append(mock_simrun.errorMessage)
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertIn(
+            error_message, committed_messages,
+            "errorMessage was not set on SimulationRun before session.commit() was called",
+        )

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -235,14 +235,14 @@ class RunSolverUnitTests(BaseTestCase):
     @patch('app.services.simulation_service.discover_container_image')
     @patch('app.services.simulation_service.scoped_session')
     @patch('app.services.simulation_service.sessionmaker')
-    def test_container_non_zero_exit_marked_completed(
+    def test_container_non_zero_exit_sets_error_status(
         self, mock_sessionmaker, mock_scoped, mock_discover_image,
         mock_discover_entry, mock_executor_factory,
         mock_export_helper, mock_auralization
     ):
         """
         container.wait() returns exit code 1 (failure)
-        → currently ignored entirely → simulation still marked Completed (BUG!).
+        → RuntimeError raised → caught → simulation marked Error.
         """
         mock_simrun = self._make_mock_simrun()
         mock_simulation = self._make_mock_simulation()
@@ -258,10 +258,11 @@ class RunSolverUnitTests(BaseTestCase):
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
 
-        # BUG: should be Error but is Completed
-        self.assertEqual(mock_simrun.status, Status.Completed,
-            "❌ Non-zero container exit → should be Error, not Completed!")
-        print("❌ container.wait()=1 → Completed anyway (BUG: exit code ignored)")
+        self.assertEqual(mock_simrun.status, Status.Error,
+            "❌ Non-zero container exit → SimulationRun status should be Error")
+        self.assertEqual(mock_simulation.status, Status.Error,
+            "❌ Non-zero container exit → Simulation status should be Error")
+        print("✅ container.wait()={'StatusCode': 1} → Error status set correctly")
     
     @patch('app.services.simulation_service.scoped_session')
     @patch('app.services.simulation_service.sessionmaker')

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -396,8 +396,12 @@ class RunSolverErrorMessageTests(BaseTestCase):
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
 
-        self.assertIn("Exit code 1", mock_simrun.errorMessage)
-        self.assertIn("Exit code 1", mock_simulation.errorMessage)
+        self.assertIn(
+            "Please check the container logs or terminal output for more details",
+            mock_simrun.errorMessage)
+        self.assertIn(
+            "Please check the container logs or terminal output for more details",
+            mock_simulation.errorMessage)
 
     @patch("app.services.simulation_service.executor_factory")
     @patch("app.services.simulation_service.discover_entry_file")
@@ -435,8 +439,8 @@ class RunSolverErrorMessageTests(BaseTestCase):
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
 
-        self.assertIn("Exit code 1", mock_simrun.errorMessage)
-        self.assertIn("Exit code 1", mock_simulation.errorMessage)
+        self.assertIn("Please check the container logs or terminal output for more details", mock_simrun.errorMessage)
+        self.assertIn("Please check the container logs or terminal output for more details", mock_simulation.errorMessage)
 
     @patch("app.services.simulation_service.executor_factory")
     @patch("app.services.simulation_service.discover_entry_file")

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -183,7 +183,7 @@ class RunSolverUnitTests(BaseTestCase):
 
         mock_discover_image.return_value = "dg_image:latest"
         mock_discover_entry.return_value = "DGInterface.py"
-        mock_executor_factory.return_value.execute.return_value.wait.return_value = 0
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 0}
         mock_export_helper.parse_json_file_to_xlsx_file.return_value = True
         mock_export_helper.write_data_to_xlsx_file.side_effect = Exception("Auralization failed")  # FAILS after session.add
 
@@ -219,7 +219,7 @@ class RunSolverUnitTests(BaseTestCase):
 
         mock_discover_image.return_value = "de_image:latest"
         mock_discover_entry.return_value = "DEInterface.py"
-        mock_executor_factory.return_value.execute.return_value.wait.return_value = 0
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 0}
         mock_export_helper.parse_json_file_to_xlsx_file.return_value = False  # Trigger bug
 
         simulation_service.run_solver(self.simulation_run_id, self.json_path)
@@ -251,7 +251,7 @@ class RunSolverUnitTests(BaseTestCase):
 
         mock_discover_image.return_value = "dg_image:latest"
         mock_discover_entry.return_value = "DGinterface.py"
-        mock_executor_factory.return_value.execute.return_value.wait.return_value = 1  # FAIL
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 1}  # FAIL
         mock_export_helper.parse_json_file_to_xlsx_file.return_value = True
         mock_export_helper.write_data_to_xlsx_file.return_value = True
         mock_auralization.return_value = ([0.1, 0.2], 44100)

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 import os
+import tempfile
 from unittest.mock import patch, MagicMock, call
 from pathlib import Path
 from datetime import datetime

--- a/tests/unit/services/test_run_solver.py
+++ b/tests/unit/services/test_run_solver.py
@@ -507,3 +507,113 @@ class RunSolverErrorMessageTests(BaseTestCase):
             error_message, committed_messages,
             "errorMessage was not set on SimulationRun before session.commit() was called",
         )
+
+
+class RunSolverCancellationTests(BaseTestCase):
+    """Verify Status.Cancelled is set on both models when a simulation is cancelled."""
+
+    def setUp(self):
+        super().setUp()
+        self.simulation_run_id = 123
+        fd, self.json_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        self._task_id = "test-task-cancel"
+        self._base_json = {
+            "task_id": self._task_id,
+            "simulationSettings": {},
+            "results": [{"resultType": "DE", "responses": [{"receiverResults": []}]}],
+        }
+        with open(self.json_path, "w") as f:
+            json.dump(self._base_json, f)
+        self._cancel_flag_path = str(Path(self.json_path).parent / f"{self._task_id}.cancel")
+
+    def tearDown(self):
+        for path in (self.json_path, self._cancel_flag_path):
+            if os.path.exists(path):
+                os.chmod(path, 0o644)
+                os.unlink(path)
+        super().tearDown()
+
+    def _make_mock_session(self, mock_simrun, mock_simulation):
+        mock_session = MagicMock()
+        def query_side_effect(model_class):
+            mock_query = MagicMock()
+            if model_class.__name__ == "SimulationRun":
+                mock_query.get.return_value = mock_simrun
+            elif model_class.__name__ == "Simulation":
+                mock_query.filter_by.return_value.first.return_value = mock_simulation
+            return mock_query
+        mock_session.query.side_effect = query_side_effect
+        return mock_session
+
+    def _make_mock_simrun(self):
+        m = MagicMock()
+        m.id = self.simulation_run_id
+        m.status = Status.Created
+        return m
+
+    def _make_mock_simulation(self):
+        m = MagicMock()
+        m.id = 456
+        m.solverSettings = {"simulationSettings": {}}
+        m.settingsPreset = MagicMock(value="Default")
+        m.simulationMethod = "DE"
+        m.resourceType = ResourceType.LOCAL
+        m.status = Status.Created
+        m.simulationRunId = self.simulation_run_id
+        return m
+
+    @patch("app.services.simulation_service.auralization_calculation")
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_cancelled_status_set_when_exit_137_with_cancel_flag(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory, mock_auralization
+    ):
+        """
+        Container exits with code 137 (SIGKILL) and cancel flag exists
+        → Status.Cancelled written to both models.
+        """
+        Path(self._cancel_flag_path).touch()
+
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 137}
+        mock_auralization.return_value = ([0.0], 44100)
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.status, Status.Cancelled)
+        self.assertEqual(mock_simulation.status, Status.Cancelled)
+
+    @patch("app.services.simulation_service.executor_factory")
+    @patch("app.services.simulation_service.discover_entry_file")
+    @patch("app.services.simulation_service.discover_container_image")
+    @patch("app.services.simulation_service.scoped_session")
+    @patch("app.services.simulation_service.sessionmaker")
+    def test_error_status_set_when_exit_137_without_cancel_flag(
+        self, mock_sessionmaker, mock_scoped,
+        mock_discover_image, mock_discover_entry, mock_executor_factory
+    ):
+        """
+        Container exits with code 137 (SIGKILL) but no cancel flag exists
+        → treated as OOM/kill → Status.Error written to both models.
+        """
+        mock_simrun = self._make_mock_simrun()
+        mock_simulation = self._make_mock_simulation()
+        mock_scoped.return_value.return_value = self._make_mock_session(mock_simrun, mock_simulation)
+        mock_discover_image.return_value = "de_image:latest"
+        mock_discover_entry.return_value = "DEInterface.py"
+        mock_executor_factory.return_value.execute.return_value.wait.return_value = {"StatusCode": 137}
+
+        simulation_service.run_solver(self.simulation_run_id, self.json_path)
+
+        self.assertEqual(mock_simrun.status, Status.Error)
+        self.assertEqual(mock_simulation.status, Status.Error)
+        self.assertIn("killed", mock_simrun.errorMessage.lower())


### PR DESCRIPTION
### Proposed changes

- Add support for tacking different StatusCodes and error messages to the CloudExecutor and simulation task
- Handle and propagate errors in the simulation task
  -  Explicitly raised errors by simulation methods are propagated with specific error message
  - Unexpected errors are propagated with generic error message
  - Errors outside the docker container are forwarded with a minimal matching message if available. 
- Set up models and schema for error messages.

requires https://github.com/choras-org/frontend-v2/pull/185