### PR TITLE
ENH: Reduce gmsh verbosity level

### DIFF
--- a/app/services/mesh_service.py
+++ b/app/services/mesh_service.py
@@ -143,6 +143,8 @@ def attach_geo_file(model_id, file_input_id):
 
 
 gmsh.initialize()
+# Set the gmsh verbosity level to only show errors and warnings
+gmsh.option.setNumber("General.Verbosity", 2)
 
 
 def start_mesh_task(model_id):


### PR DESCRIPTION
### Proposed changes

Reduce the verbosity level of Gmsh to 2, which corresponds to errors & warnings.
This avoids spamming the logs with detailed information on the mesh, which can lead to overlooking relevant warnings in a very noisy log.