### PR TITLE
FIX: Use sampling rate defined in the auralization settings

### DIFF
--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -290,7 +290,6 @@ def start_solver_task(simulation_id):
                     "geo_path": geo_path,
                     "results": results_container,
                     "task_id": -1,
-                    "fs_auralization": 44100,
                 },
                 indent=4,
             )
@@ -449,7 +448,12 @@ def run_solver(simulation_run_id: int, json_path: str):
                         if "sampling_rate" in input_data["simulationSettings"]:
                             fs = input_data["simulationSettings"]["sampling_rate"]
                         else:
-                            fs = input_data["fs_auralization"]  # 44100 by default
+                            from config import AuralizationParametersConfig
+                            fs = AuralizationParametersConfig.visualization_fs
+                            logger.warning(
+                                "The sampling rate of the impulse response was not provided. " +
+                                f"Assuming {fs} as fallback."
+                            )
 
                     rir_wav_file_name = json_path.replace(".json", ".wav")
 

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -451,8 +451,7 @@ def run_solver(simulation_run_id: int, json_path: str):
                             from config import AuralizationParametersConfig
                             fs = AuralizationParametersConfig.visualization_fs
                             logger.warning(
-                                "The sampling rate of the impulse response was not provided. " +
-                                f"Assuming {fs} as fallback."
+                                f"The sampling rate of the impulse response was not provided. Assuming {fs} as fallback."
                             )
 
                     rir_wav_file_name = json_path.replace(".json", ".wav")


### PR DESCRIPTION
Currently, the simulation service defines a hard-coded sampling rate which is used as fallback in case the sampling rate is not provided by the simulation method.
Instead, this PR implements falling back to the sampling rate defined in the `AuralizationParametersConfig` in `config.py`.

Related to https://github.com/choras-org/CHORAS/issues/45