### PR TITLE
MAINT: Install acousticDE via PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     'paramiko',
     'pyfar',
     'shapely==2.1.2',
-    'acousticDE @ git+https://github.com/Building-acoustics-TU-Eindhoven/acousticDE.git@d32afb2498e27bd996fc7356d57dc4f1ed76aa44',
+    'acousticDE==0.1.0',
 ]
 
 [dependency-groups]


### PR DESCRIPTION
### Proposed

Replace install from git commit id with explicitly installing acosuticDE==0.1.0 via pypi

This makes building the wheel obsolete when installing