### PR TITLE
MAINT: Update dependencies in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'docker',
     'paramiko',
     'pyfar',
-    'shapely==2.1.2', # is this exact pin actually required?
+    'shapely==2.1.2', # exact pin maybe not required
     'acousticDE==0.1.0',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,9 @@ classifiers = [
 
 dependencies = [
     'alembic>=1.10.2',
-    'amqp>=5.2.0',
     'celery>=5.4.0',
     'click>=8.1.3',
-    'click-didyoumean>=0.3.1',
-    'click-plugins>=1.1.1',
-    'click-repl>=0.3.0',
-    'debugpy>=1.6.4',
-    'docutils>=0.21.2',
     'eventlet>=0.36.1', # Discouraged for use now, but seems to be used within celery
-    'executing>=1.2.0',
     'Flask>=2.2.5', # explicitly imported
     'Flask-Cors>=3.0.10', # explicitly imported
     'Flask-JWT-Extended>=4.4.4', # explicitly imported
@@ -39,17 +32,12 @@ dependencies = [
     'Flask-SQLAlchemy>=3.0.3',
     'gmsh>=4.13.1', # explicitly imported (in simulation service)
     'gunicorn>=20.1.0',
-    'Jinja2>=3.1.2',
     'marshmallow>=3.13.0', # explicitly imported
-    'nodeenv>=1.9.1',
     'numpy',
-    'openpyxl',
+    'openpyxl', # explicitly required by pandas Excel file writer (although not explicitly imported)
     'pandas',
-    'parso>=0.8.3',
     'passlib>=1.7.4', # explicitly imported
-    'pre-commit>=3.8.0',
     'psycopg2-binary>=2.9.6',
-    'PyJWT>=2.6.0',
     'python-dotenv>=1.0.0', # explicitly imported
     'pytz>=2023.3', # explicitly imported (dependency)
     'rhino3dm>=8.6.1', # explicitly imported (Mesh handling)
@@ -57,14 +45,13 @@ dependencies = [
     'soundfile>=0.13.1', # explicitly imported (for auralization service)
     'SQLAlchemy>=2.0.7', # explicitly imported
     'trimesh>=4.4.1', # explicitly imported (ObjConversion, Mesh handling)
-    'typing_extensions',
     'tzdata>=2023.3',
     'Werkzeug>=2.2.3', # explicitly imported (auralization service)
     'ezdxf', # explicitly imported (for DXF file handling, Mesh handling)
     'docker',
     'paramiko',
     'pyfar',
-    'shapely==2.1.2',
+    'shapely==2.1.2', # is this exact pin actually required?
     'acousticDE==0.1.0',
 ]
 
@@ -77,10 +64,13 @@ docs = [
     'sphinx-design',
     'sphinx-copybutton',
     'matplotlib',
+    'docutils>=0.21.2',
 ]
 
 tests = [
     'pytest',
+    'debugpy>=1.6.4',
+    'pre-commit>=3.8.0',
     'coverage>=7.2.7',
     'black==25.1.0',
     'isort==5.12.0',


### PR DESCRIPTION
- Removes all sub-dependencies from the explicit dependencies
- Moves development and docs dependencies to their groups
- Added additional comments on dependency kind