### PR TITLE
CI: Fixture create mocked simulation-method config

### DIFF
--- a/.github/workflows/engd2026.yml
+++ b/.github/workflows/engd2026.yml
@@ -49,67 +49,11 @@ jobs:
             libgl1 \
             mesa-utils
           uv sync --group tests
-      - name: Create mock methods-config.json and settings for CI
-        run: |
-          mkdir -p ${{ github.workspace }}/simulation-backend
-          mkdir -p ${{ github.workspace }}/simulation-backend/example_settings
-          cat > ${{ github.workspace }}/simulation-backend/methods-config.json << 'EOF'
-          [
-            {
-              "simulationType": "DG",
-              "containerImage": "dg_image:latest",
-              "envVars": {"CUDA_VISIBLE_DEVICES": "0"},
-              "label": "Discontinuous Galerkin method",
-              "settings": "dg_setting.json",
-              "entryFile": "DGinterface.py",
-              "repositoryURL": "https://github.com/Building-acoustics-TU-Eindhoven/edg-acoustics/",
-              "documentationURL": "https://dg-roomacoustics.readthedocs.io/en/latest/"
-            },
-            {
-              "simulationType": "DE",
-              "containerImage": "de_image:latest",
-              "envVars": {},
-              "label": "Diffusion Equation method",
-              "settings": "de_setting.json",
-              "entryFile": "DEinterface.py",
-              "repositoryURL": "https://github.com/Building-acoustics-TU-Eindhoven/acousticDE/",
-              "documentationURL": "https://building-acoustics-tu-eindhoven.github.io/acousticDE/index.html"
-            },
-            {
-              "simulationType": "MyNewMethod",
-              "containerImage": "mynew_image:latest",
-              "envVars": {},
-              "label": "My New Method",
-              "entryFile": "MyNewMethodInterface.py",
-              "settings": "my_new_setting.json",
-              "repositoryURL": "",
-              "documentationURL": ""
-            },
-            {
-              "simulationType": "PA",
-              "containerImage": "pa_image:latest",
-              "envVars": {},
-              "label": "Pyromacoustics Method",
-              "entryFile": "pyroomacoustics_interface.py",
-              "settings": "examples.json",
-              "repositoryURL": "",
-              "documentationURL": ""
-            }
-          ]
-          EOF
-          # Create empty mock settings files
-          touch ${{ github.workspace }}/simulation-backend/example_settings/dg_setting.json
-          touch ${{ github.workspace }}/simulation-backend/example_settings/de_setting.json
-          touch ${{ github.workspace }}/simulation-backend/example_settings/my_new_setting.json
-          touch ${{ github.workspace }}/simulation-backend/example_settings/examples.json
-
       - name: Run tests
         env:
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
           APP_TEST_SETTINGS_MODULE: config.TestingConfigs
           TESTING: "true"
-          METHODS_CONFIG_PATH: ${{ github.workspace }}/simulation-backend/methods-config.json
-          SETTINGS_FILE_FOLDER: ${{ github.workspace }}/simulation-backend/example_settings
         run: |
             uv run pytest tests/integration tests/unit/services/test_discovery_service.py tests/unit/services/test_run_solver.py
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+import json
+import os
+
+import pytest
+
+from config import DefaultConfig
+
+_MOCK_METHODS_CONFIG = [
+    {
+        "simulationType": "DG",
+        "containerImage": "dg_image:latest",
+        "envVars": {"CUDA_VISIBLE_DEVICES": "0"},
+        "label": "Discontinuous Galerkin method",
+        "settings": "dg_setting.json",
+        "entryFile": "DGinterface.py",
+        "repositoryURL": "https://github.com/Building-acoustics-TU-Eindhoven/edg-acoustics/",
+        "documentationURL": "https://dg-roomacoustics.readthedocs.io/en/latest/",
+    },
+    {
+        "simulationType": "DE",
+        "containerImage": "de_image:latest",
+        "envVars": {},
+        "label": "Diffusion Equation method",
+        "settings": "de_setting.json",
+        "entryFile": "DEinterface.py",
+        "repositoryURL": "https://github.com/Building-acoustics-TU-Eindhoven/acousticDE/",
+        "documentationURL": "https://building-acoustics-tu-eindhoven.github.io/acousticDE/index.html",
+    },
+    {
+        "simulationType": "MyNewMethod",
+        "containerImage": "mynew_image:latest",
+        "envVars": {},
+        "label": "My New Method",
+        "entryFile": "MyNewMethodInterface.py",
+        "settings": "my_new_setting.json",
+        "repositoryURL": "",
+        "documentationURL": "",
+    },
+    {
+        "simulationType": "PA",
+        "containerImage": "pa_image:latest",
+        "envVars": {},
+        "label": "Pyromacoustics Method",
+        "entryFile": "pyroomacoustics_interface.py",
+        "settings": "examples.json",
+        "repositoryURL": "",
+        "documentationURL": "",
+    },
+]
+
+
+@pytest.fixture
+def simulation_backend_files(tmp_path, monkeypatch):
+    """Point DefaultConfig at mock simulation-backend files in a temp dir.
+
+    Skips creation if real files are already present on disk (local dev with a
+    real simulation-backend checkout). Apply explicitly via
+    @pytest.mark.usefixtures for unittest.TestCase subclasses.
+    """
+    if os.path.exists(DefaultConfig.METHODS_CONFIG_PATH) and os.path.isdir(
+        DefaultConfig.SETTINGS_FILE_FOLDER
+    ):
+        return
+
+    settings_dir = tmp_path / "example_settings"
+    settings_dir.mkdir()
+
+    config_file = tmp_path / "methods-config.json"
+    config_file.write_text(json.dumps(_MOCK_METHODS_CONFIG))
+
+    for entry in _MOCK_METHODS_CONFIG:
+        if entry.get("settings"):
+            (settings_dir / entry["settings"]).touch()
+
+    monkeypatch.setattr(DefaultConfig, "METHODS_CONFIG_PATH", str(config_file))
+    monkeypatch.setattr(DefaultConfig, "SETTINGS_FILE_FOLDER", str(settings_dir))

--- a/tests/unit/services/test_discovery_service.py
+++ b/tests/unit/services/test_discovery_service.py
@@ -3,11 +3,14 @@ import os
 import json
 from pathlib import Path
 
+import pytest
+
 from app.services import discovery_service
 from tests.unit import BaseTestCase
 from config import DefaultConfig
 
 
+@pytest.mark.usefixtures("simulation_backend_files")
 class DiscoveryServiceUnitTests(BaseTestCase):
     def setUp(self):
         """


### PR DESCRIPTION
- Create a fixture in conftest.py
- Move creation of mock config file from github action to conftest

This way, the tests can be executed locally and via ci server without needing to check out simulation method sub-modules